### PR TITLE
chore(release): v0.4.0 — close M4/M5/M6 unreleased block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,45 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-30
+
 ### Added
 
-- **M5 Import Resolver**: dependency-aware context selection — follows import chains to auto-include relevant files for refactor, bugfix, test-gen, and schema-migration tasks
-- **M5 Strategy-based repair**: multi-retry recovery with targeted strategies (typecheck -> lint -> test -> all), up to 3 repair attempts instead of 1
-- **M5 Repair metadata**: `repairAttempts` and `repairStrategies` fields in job result for observability on draft PRs
-- **M5 Builder tools**: `search_files` (regex grep across project) and `list_files` (directory listing) for refactoring and exploration
-- **M5 Improved prompts**: step-by-step workflows for refactor, bugfix, test-gen, and schema-migration tasks
-- **M5 tests**: 35 new tests for import-resolver, strategy-based validator, and new tools (748 total, up from 713)
+#### M6 Cosmos (3D — Planetary Transformation)
 
-### Changed
+- Service stars on concentric rings (emissive sphere + glow + corona, color by service type)
+- Endpoint planets with method-based shapes (GET=sphere, POST=icosahedron, PUT=torus, DELETE=octahedron, PATCH=dodecahedron)
+- Curved luminous routes (CatmullRomCurve3 + TubeGeometry) with animated pulse along the curve
+- Wormhole auth gate effect (portal/transit visualization for auth-required services)
+- Orbital navigation: OrbitControls with smooth damping, click-to-focus camera animation, auto-rotate when idle
+- Cosmos / Tron mode switch via `view.store.ts` (Tron city retained as legacy mode)
+- Dark and light themes selectable from view store
+- Orbital layout engine in `utils/cosmos.ts` (concentric ring placement, non-overlapping planetary systems)
+- New components: `Cosmos.tsx`, `ServiceStar.tsx`, `EndpointPlanet.tsx`, `OrbitalPath.tsx`, `CurvedRoute.tsx`, `Wormhole.tsx`
 
-- Builder context reader now accepts `inferredFiles` parameter for dependency-resolved context
-- Builder service uses `categorizeErrors` + `pickRepairStrategy` instead of generic `formatValidationErrors` for repair loop
-- Task prompts expanded with concrete workflows and tool usage guidance
+#### M5 Builder v2 (Agent — Smart Context + Multi-Retry)
 
----
+- **Import Resolver**: dependency-aware context selection — follows import chains (depth 2) to auto-include relevant files for refactor, bugfix, test-gen, and schema-migration tasks
+- **Strategy-based repair**: multi-retry recovery with targeted strategies (typecheck → lint → test → all), up to 3 repair attempts instead of 1
+- **Repair metadata**: `repairAttempts` and `repairStrategies` fields in job result for observability on draft PRs
+- **New builder tools**: `search_files` (regex grep across project) and `list_files` (directory listing) added to the Claude tool-use loop
+- **Improved task prompts**: step-by-step workflows for refactor, bugfix, test-gen, and schema-migration tasks
 
-- **M4 Atmosphere**: post-processing pipeline (bloom, SSAO, depth of field, vignette, chromatic aberration, noise), cosmic skybox (star field, nebulae, dust particles), animated key light, ground fog, haze layers, pulse wave effect
-- **M4 Galaxy Settings panel**: real-time sliders for all atmosphere parameters (layout, stars, planets, routes, bloom, post-processing, atmosphere, camera)
-- **Cinematic camera system**: 5 keyframe-based presets (Grand Orbit, Flythrough, Top-Down Sweep, Dramatic Rise, Nebula Tour) with smooth-step easing, play/pause/stop/speed controls
-- **Ultra quality mode**: custom GLSL shader nebulae (6-octave fBM simplex noise, 7 palettes), 12,000 spectral-class stars, 2,500 dust particles with trails, extended far plane
-- **Rich nebulae**: multi-layer procedural textures with 5 astronomical palettes (Helix, Carina, Eagle, Orion, Cat's Eye), annular ring structure, bright knots, filaments
-- **FPS counter**: real-time frame rate display in HUD (color-coded: green/yellow/red)
-- **Cosmos settings store**: Zustand store for all tunable 3D scene parameters with reset-to-defaults
-- **Cinematic store**: Zustand store for camera preset playback state
-- **M3 AI Builder pipeline**: prompt-to-PR code generation via Claude API with tool use
+#### M4 Atmosphere (3D — Cinematic Visuals)
+
+- Post-processing pipeline: bloom (UnrealBloomPass), SSAO, depth of field, vignette, chromatic aberration, film grain
+- Cosmic skybox: star field, nebulae, dust particles, animated key light, ground fog, haze layers, pulse wave effect
+- Galaxy Settings panel: real-time sliders for all atmosphere parameters (layout, stars, planets, routes, bloom, post-processing, atmosphere, camera)
+- Cinematic camera system: 5 keyframe-based presets (Grand Orbit, Flythrough, Top-Down Sweep, Dramatic Rise, Nebula Tour) with smooth-step easing, play/pause/stop/speed controls
+- Ultra quality mode: custom GLSL shader nebulae (6-octave fBM simplex noise, 7 palettes), 12,000 spectral-class stars, 2,500 dust particles with trails, extended far plane
+- Rich nebulae: multi-layer procedural textures with 5 astronomical palettes (Helix, Carina, Eagle, Orion, Cat's Eye), annular ring structure, bright knots, filaments
+- FPS counter: real-time frame rate display in HUD (color-coded green/yellow/red)
+- `cosmos-settings.store.ts`: Zustand store for all tunable 3D scene parameters with reset-to-defaults
+- Cinematic store: Zustand store for camera preset playback state
+
+#### M3.1 Two-Phase Builder (Agent — Plan/Approve Gate)
+
+- Plan-then-generate pipeline with user approval gate
+- New pipeline states: `queued → planning → plan_ready → [approve/reject] → reading_context → generating → ... → completed` (11 states total)
+- Plan generation via single Claude API call returning structured file manifest (path, type, action, description)
+- New routes: `POST /api/v1/builder/jobs/:id/approve` and `POST /api/v1/builder/jobs/:id/reject` (admin-only)
+- Plan review UI in BuilderPromptBar: editable file manifest with type badges, inline description editing, approve/reject buttons
+- Glowy animated loading bar with CSS keyframe animations (shimmer, glow, pulse, indeterminate)
+- Context reduction for plan-constrained generation (~40-50% fewer tokens)
+- 10-minute timeout guard on both planning and generation phases
+- Plan field added to BuilderJob model and schema (Mongoose sub-schema + Zod)
+
+#### M3 AI Builder Pipeline (Agent — Prompt to PR)
+
+- Prompt-to-PR code generation via Claude API with tool use (multi-turn loop: write_file, modify_file, read_file)
 - Builder routes: `POST /api/v1/builder/generate`, `GET /api/v1/builder/jobs/:id`, `GET /api/v1/builder/jobs`
-- Builder job model with MongoDB audit trail (status tracking across 11 pipeline states)
+- Builder job model with MongoDB audit trail (status tracking across pipeline states)
 - Scope policy engine: path whitelist/blacklist, forbidden path detection, dangerous content scanning
 - Context reader: builds LLM context bundle from project codebase (CLAUDE.md, schemas, models, services, routes)
-- Code generator: multi-turn Claude API loop with write_file, modify_file, read_file tools
-- Self-repair: validation failure triggers one repair attempt via Claude before failing
+- Self-repair: validation failure triggers repair attempt via Claude before failing
 - Project validator: runs typecheck, lint, and test via child_process with 60s timeout
 - File writer with scope policy enforcement and recursive directory creation
 - Git operations: branch creation, commit with conventional format, push, cleanup via simple-git
 - GitHub PR creation via Octokit with structured body (summary, file lists, risk checklist)
 - Builder world notifier: emits `builder.progress` delta events and synthetic service/endpoint deltas via WebSocket
-- `builder.progress` event type added to WorldDeltaEvent discriminated union (9th event type)
-- Builder tools added to MCP manifest (builder_generate, builder_get_job, builder_list_jobs)
+- `builder.progress` event type added to WorldDeltaEvent discriminated union
+- Builder tools registered in MCP manifest (`builder_generate`, `builder_get_job`, `builder_list_jobs`)
 - Builder env vars: `BUILDER_ENABLED`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `GITHUB_OWNER`, `GITHUB_REPO`, `BUILDER_RATE_LIMIT_MAX`, `BUILDER_RATE_LIMIT_WINDOW_MS`
 - Pino logger redaction for sensitive keys (ANTHROPIC_API_KEY, GITHUB_TOKEN, JWT secrets)
 - Builder kill switch: `BUILDER_ENABLED=false` returns 503
@@ -58,16 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `builder.progress` delta event forwarding from world store to builder store
 - Seed admin user (`admin@formray.io`) created automatically on every server start
 - `detail` field on `builder.progress` delta events for granular tool activity reporting
-- **M3.1 Two-Phase Builder**: plan-then-generate pipeline with user approval gate
-- Two-phase pipeline: `queued → planning → plan_ready → [approve/reject] → reading_context → generating → ... → completed`
-- Plan generation via single Claude API call returning structured file manifest (path, type, action, description)
-- `POST /api/v1/builder/jobs/:id/approve` and `POST /api/v1/builder/jobs/:id/reject` endpoints (admin-only)
-- Plan review UI in BuilderPromptBar: editable file manifest with type badges, inline description editing, approve/reject buttons
-- Glowy animated loading bar with CSS keyframe animations (shimmer, glow, pulse, indeterminate)
-- Context reduction for plan-constrained generation (~40-50% fewer tokens)
-- 10-minute timeout guard on both planning and generation phases
-- Plan field added to BuilderJob model and schema (Mongoose sub-schema + Zod)
-- 560 server tests across 61 test files + 159 client tests across 12 test files
+
+#### M2 World Model + Realtime Stream (3D — Foundation)
 
 - World model Zod schemas (WorldService, WorldEndpoint, WorldEdge, WorldModel) with schema version 1
 - ProjectionService for OpenAPI 3.x to WorldModel transformation (tag grouping, pairwise edges, auth detection)
@@ -76,21 +92,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - World WS message handlers for subscribe flow (full snapshot and resume with catch-up) and ping/pong keepalive
 - World Gateway WebSocket endpoint at `GET /api/v1/world-ws` with JWT query-param authentication
 - Environment variables: `WORLD_WS_BUFFER_SIZE` (default 1000), `WORLD_WS_RESUME_TTL_MS` (default 5min)
-- Integration tests for ProjectionService (live OpenAPI parsing) and World WS (subscribe, snapshot, resume flows)
-- Unit tests for world schemas, projection service, world WS manager, and world handlers (97 new tests)
 - React + R3F client scaffold (`client/`) with Vite 6, React 19, Three.js 0.173, Zustand 5
 - Client-side WorldModel types mirroring backend Zod schemas (plain TypeScript interfaces)
 - WebSocket connection hook with auto-reconnect (3s), ping/pong (25s), and resume token support
 - Zustand stores for world state and building selection
 - Deterministic grid layout service (services → districts, endpoints → buildings)
-- 3D city renderer: buildings colored by HTTP method, hover glow, click selection
+- 3D city renderer (Tron mode): buildings colored by HTTP method, hover glow, click selection
 - District ground planes with service tag labels and edge connectors
 - HUD overlay with connection status indicator and HTTP method color legend
 - Side panel with endpoint details (path, method, summary, auth, params, related endpoints)
 - Client CI job (lint, typecheck, test, build) in GitHub Actions
-- Client unit tests for layout service, Zustand store, and color mappings (24 new tests)
-- WS protocol contract tests validating producer/consumer message schemas (31 tests)
-- Demo dry run e2e tests verifying M1 acceptance criteria: 100% endpoint mapping, zero crashes, performance under 1.2s, correct metadata, building non-overlap (23 tests)
 - 3D world docs index (`docs/3d-world/README.md`) and M2 realtime overlay execution plan
 
 ### Fixed
@@ -99,6 +110,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - World WS resume validation now rejects future timestamps in resume tokens
 - Client WS hook hardened against malformed messages and stale socket lifecycle race conditions
 - Setup/bootstrap docs updated for 3D client token flow (`client/.env.example`, Quickstart, root README)
+
+### Tests
+
+- 748 server tests across 66 test files (up from 560 at v0.3.0): added M5 import-resolver, strategy-based validator, search_files/list_files (35 new), M3.1 two-phase pipeline, M3 builder pipeline, M2 world projection (97 new)
+- 244 client tests across 20 test files (up from 159): added M6 cosmos layout, planet shapes, theme switching, M4 atmosphere, settings panel, cinematic preset playback
+
+### Security
+
+- Patched security vulnerabilities in `hono`, `minimatch`, `fast-xml-parser` (transitive)
 
 ## [0.3.0] - 2026-02-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 - **Repository:** `https://github.com/formray/fenice`
 - **Organization:** Formray
-- **Version:** 0.3.0 (latest on `main`)
+- **Version:** 0.4.0 (latest on `main`)
 - **License:** MIT
 - **Author:** Giuseppe Albrizio
 
@@ -81,7 +81,7 @@ npm run start          # Run compiled output (node dist/server.js)
 
 ### Commits
 - **Conventional Commits** required: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`
-- Co-Author line: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+- Co-Author line: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
 - Husky + lint-staged pre-commit hooks run ESLint + Prettier automatically
 
 ## Architecture
@@ -219,8 +219,45 @@ POST /api/v1/builder/generate  (JWT + admin + rate limit 5/hour)
 - **Timeouts:** 10-minute guard on both planning and generation phases
 - **M5 Smart context:** Import resolver follows dependency chains (depth 2) for refactor/bugfix/test-gen tasks
 - **M5 Multi-retry:** Strategy-based repair (typecheck -> lint -> test -> all), up to 3 attempts
+- **M5 Tools:** `search_files` (regex grep) + `list_files` (directory listing) added to Claude tool-use loop
 - **World integration:** `builder.progress` delta events + synthetic `service.upserted`/`endpoint.upserted` deltas
 - **Deps:** `@anthropic-ai/sdk`, `simple-git`, `@octokit/rest`
+
+### 3D World (M4 Atmosphere + M6 Cosmos)
+The client is a React 19 + R3F application that renders the API surface as a navigable cosmic universe.
+
+```
+client/src/
+  components/
+    Scene.tsx                # Root R3F canvas + post-processing pipeline
+    Cosmos.tsx               # Cosmos mode: stars, orbits, planets, routes
+    ServiceStar.tsx          # Service-as-star (emissive sphere + corona)
+    EndpointPlanet.tsx       # Endpoint-as-planet (shape by HTTP method)
+    OrbitalPath.tsx          # Semi-transparent orbital ellipses
+    CurvedRoute.tsx          # CatmullRom-curved luminous edge with pulse
+    Wormhole.tsx             # Auth gate as portal effect
+    Nebulae.tsx              # Multi-layer procedural nebula sprites
+    ShaderNebulae.tsx        # Ultra mode: GLSL fBM nebulae (7 palettes)
+    DustParticles.tsx        # Floating dust with sin/cos drift
+    CameraController.tsx     # OrbitControls + cinematic preset playback
+    CosmosSettings.tsx       # Galaxy Settings panel (real-time sliders)
+    HUD.tsx                  # Connection status, FPS, legend, prompt bar
+    atmosphere/
+      GroundFog.tsx          # FogExp2 + ground haze
+      HazeLayers.tsx         # Multi-layer atmospheric haze
+    builder/                 # Builder prompt bar + plan review UI
+  stores/
+    cosmos-settings.store.ts # Zustand store for tunable scene parameters
+    view.store.ts            # Cosmos/Tron mode + dark/light theme
+  utils/
+    cosmos.ts                # Orbital layout math (concentric rings)
+```
+
+- **Visual modes:** `cosmos` (planetary) and `tron` (legacy city) toggleable via view store
+- **Themes:** dark (default cosmic) and light
+- **Quality tiers:** standard, ultra (custom GLSL nebulae + 12k spectral stars + 2.5k dust)
+- **Cinematic camera:** 5 keyframe presets (Grand Orbit, Flythrough, Top-Down Sweep, Dramatic Rise, Nebula Tour)
+- **Post-processing:** UnrealBloomPass, SSAO, depth of field, vignette, chromatic aberration, film grain
 
 ## Testing
 
@@ -228,7 +265,7 @@ POST /api/v1/builder/generate  (JWT + admin + rate limit 5/hour)
 - **Property testing:** fast-check for schema validation properties
 - **Coverage:** v8 provider, thresholds at 60/40/50/60 (stmts/branches/funcs/lines). DB-dependent files (services, models, production adapters) excluded — need MongoDB integration tests.
 - **Test structure:** `tests/unit/`, `tests/integration/`, `tests/properties/`
-- **Current status:** 589 server tests across 66 test files + 159 client tests across 12 test files, all passing
+- **Current status:** 748 server tests across 66 test files + 244 client tests across 20 test files, all passing
 - **TDD preferred:** Write tests alongside or before implementation
 
 ## Common Gotchas

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -25,5 +25,5 @@ export default tseslint.config(
   },
   {
     ignores: ['dist/', 'node_modules/', '*.config.*'],
-  },
+  }
 );

--- a/client/index.html
+++ b/client/index.html
@@ -5,9 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FENICE 3D World</title>
     <style>
-      * { margin: 0; padding: 0; box-sizing: border-box; }
-      html, body, #root { width: 100%; height: 100%; overflow: hidden; }
-      body { background: #0a0a14; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+      }
+      body {
+        background: #0a0a14;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
     </style>
   </head>
   <body>

--- a/client/src/__tests__/world-semantic-store.test.ts
+++ b/client/src/__tests__/world-semantic-store.test.ts
@@ -103,39 +103,33 @@ describe('world.store — semantic integration', () => {
   it('setWorldModel resets stale metrics classifier state', () => {
     useWorldStore.getState().setSessionState('valid');
 
-    useWorldStore
-      .getState()
-      .applyDelta(
-        makeDelta(11, [
-          {
-            type: 'endpoint.metrics.updated',
-            entityId: 'ep:public',
-            payload: { rps: 10, p50: 30, p95: 700, errorRate: 0.01 },
-          },
-        ])
-      );
-    useWorldStore
-      .getState()
-      .applyDelta(
-        makeDelta(12, [
-          {
-            type: 'endpoint.metrics.updated',
-            entityId: 'ep:public',
-            payload: { rps: 12, p50: 40, p95: 650, errorRate: 0.02 },
-          },
-        ])
-      );
-    useWorldStore
-      .getState()
-      .applyDelta(
-        makeDelta(13, [
-          {
-            type: 'endpoint.metrics.updated',
-            entityId: 'ep:public',
-            payload: { rps: 11, p50: 35, p95: 600, errorRate: 0.01 },
-          },
-        ])
-      );
+    useWorldStore.getState().applyDelta(
+      makeDelta(11, [
+        {
+          type: 'endpoint.metrics.updated',
+          entityId: 'ep:public',
+          payload: { rps: 10, p50: 30, p95: 700, errorRate: 0.01 },
+        },
+      ])
+    );
+    useWorldStore.getState().applyDelta(
+      makeDelta(12, [
+        {
+          type: 'endpoint.metrics.updated',
+          entityId: 'ep:public',
+          payload: { rps: 12, p50: 40, p95: 650, errorRate: 0.02 },
+        },
+      ])
+    );
+    useWorldStore.getState().applyDelta(
+      makeDelta(13, [
+        {
+          type: 'endpoint.metrics.updated',
+          entityId: 'ep:public',
+          payload: { rps: 11, p50: 35, p95: 600, errorRate: 0.01 },
+        },
+      ])
+    );
     expect(useWorldStore.getState().endpointSemantics['ep:public']?.linkState).toBe('degraded');
 
     useWorldStore.getState().setWorldModel(
@@ -166,39 +160,33 @@ describe('world.store — semantic integration', () => {
   it('endpoint.removed clears stale overlay/classifier for id reuse', () => {
     useWorldStore.getState().setSessionState('valid');
 
-    useWorldStore
-      .getState()
-      .applyDelta(
-        makeDelta(11, [
-          {
-            type: 'endpoint.metrics.updated',
-            entityId: 'ep:public',
-            payload: { rps: 10, p50: 30, p95: 700, errorRate: 0.01 },
-          },
-        ])
-      );
-    useWorldStore
-      .getState()
-      .applyDelta(
-        makeDelta(12, [
-          {
-            type: 'endpoint.metrics.updated',
-            entityId: 'ep:public',
-            payload: { rps: 12, p50: 40, p95: 650, errorRate: 0.02 },
-          },
-        ])
-      );
-    useWorldStore
-      .getState()
-      .applyDelta(
-        makeDelta(13, [
-          {
-            type: 'endpoint.metrics.updated',
-            entityId: 'ep:public',
-            payload: { rps: 11, p50: 35, p95: 600, errorRate: 0.01 },
-          },
-        ])
-      );
+    useWorldStore.getState().applyDelta(
+      makeDelta(11, [
+        {
+          type: 'endpoint.metrics.updated',
+          entityId: 'ep:public',
+          payload: { rps: 10, p50: 30, p95: 700, errorRate: 0.01 },
+        },
+      ])
+    );
+    useWorldStore.getState().applyDelta(
+      makeDelta(12, [
+        {
+          type: 'endpoint.metrics.updated',
+          entityId: 'ep:public',
+          payload: { rps: 12, p50: 40, p95: 650, errorRate: 0.02 },
+        },
+      ])
+    );
+    useWorldStore.getState().applyDelta(
+      makeDelta(13, [
+        {
+          type: 'endpoint.metrics.updated',
+          entityId: 'ep:public',
+          payload: { rps: 11, p50: 35, p95: 600, errorRate: 0.01 },
+        },
+      ])
+    );
     expect(useWorldStore.getState().endpointSemantics['ep:public']?.linkState).toBe('degraded');
 
     useWorldStore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,11 @@ services:
   mongodb:
     image: mongo:7
     ports:
-      - "27017:27017"
+      - '27017:27017'
     volumes:
       - mongodb_data:/data/db
     healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      test: ['CMD', 'mongosh', '--eval', "db.adminCommand('ping')"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -15,7 +15,7 @@ services:
   app:
     build: .
     ports:
-      - "3000:3000"
+      - '3000:3000'
     environment:
       - NODE_ENV=development
       - PORT=3000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fenice",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AI-native, production-ready backend starter — Formray Engineering Guidelines compliant",
   "type": "module",
   "main": "dist/index.js",

--- a/src/adapters/email/types.ts
+++ b/src/adapters/email/types.ts
@@ -1,8 +1,3 @@
 export interface EmailAdapter {
-  send(options: {
-    to: string;
-    subject: string;
-    html: string;
-    from?: string;
-  }): Promise<void>;
+  send(options: { to: string; subject: string; html: string; from?: string }): Promise<void>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ app.doc('/openapi', (c) => ({
   openapi: '3.1.0',
   info: {
     title: 'FENICE API',
-    version: '0.3.0',
+    version: '0.4.0',
     description:
       'AI-native, production-ready backend API — Formray Engineering Guidelines compliant',
   },
@@ -129,7 +129,7 @@ app.get('/docs/llm', (c) => {
     openapi: '3.1.0',
     info: {
       title: 'FENICE API',
-      version: '0.3.0',
+      version: '0.4.0',
       description:
         'AI-native, production-ready backend API — Formray Engineering Guidelines compliant',
     },

--- a/src/middleware/requestLogger.ts
+++ b/src/middleware/requestLogger.ts
@@ -2,10 +2,7 @@ import { createMiddleware } from 'hono/factory';
 import { createLogger } from '../utils/logger.js';
 
 // Module-level logger — does not require env, uses sensible defaults
-const logger = createLogger(
-  process.env.SERVICE_NAME ?? 'fenice',
-  process.env.LOG_LEVEL ?? 'info'
-);
+const logger = createLogger(process.env.SERVICE_NAME ?? 'fenice', process.env.LOG_LEVEL ?? 'info');
 
 export const requestLogger = createMiddleware(async (c, next) => {
   const start = Date.now();

--- a/src/routes/health.routes.ts
+++ b/src/routes/health.routes.ts
@@ -52,11 +52,14 @@ const healthDetailedRoute = createRoute({
 });
 
 healthRouter.openapi(healthRoute, (c) => {
-  return c.json({
-    status: 'ok',
-    timestamp: new Date().toISOString(),
-    uptime: process.uptime(),
-  }, 200);
+  return c.json(
+    {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+    },
+    200
+  );
 });
 
 healthRouter.openapi(healthDetailedRoute, async (c) => {
@@ -66,17 +69,20 @@ healthRouter.openapi(healthDetailedRoute, async (c) => {
 
   const overallStatus = mongoStatus === 'ok' ? 'ok' : 'degraded';
 
-  return c.json({
-    status: overallStatus,
-    timestamp: new Date().toISOString(),
-    uptime: process.uptime(),
-    dependencies: {
-      mongodb: {
-        status: mongoStatus,
-        responseTime: mongoResponseTime,
+  return c.json(
+    {
+      status: overallStatus,
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+      dependencies: {
+        mongodb: {
+          status: mongoStatus,
+          responseTime: mongoResponseTime,
+        },
       },
     },
-  }, 200);
+    200
+  );
 });
 
 export { healthRouter };

--- a/src/routes/mcp.routes.ts
+++ b/src/routes/mcp.routes.ts
@@ -6,7 +6,7 @@ const mcpRouter = new Hono();
 mcpRouter.get('/mcp', async (c) => {
   return c.json({
     name: 'fenice',
-    version: '0.3.0',
+    version: '0.4.0',
     description: 'AI-native backend API — FENICE',
     capabilities: {
       tools: true,

--- a/tests/integration/builder.test.ts
+++ b/tests/integration/builder.test.ts
@@ -221,7 +221,14 @@ describe('Builder routes', () => {
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test' },
         body: JSON.stringify({
           plan: {
-            files: [{ path: 'src/schemas/x.schema.ts', type: 'schema', action: 'create', description: 'X' }],
+            files: [
+              {
+                path: 'src/schemas/x.schema.ts',
+                type: 'schema',
+                action: 'create',
+                description: 'X',
+              },
+            ],
             summary: 'Test',
           },
         }),
@@ -237,7 +244,14 @@ describe('Builder routes', () => {
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test' },
         body: JSON.stringify({
           plan: {
-            files: [{ path: 'src/schemas/x.schema.ts', type: 'schema', action: 'create', description: 'X' }],
+            files: [
+              {
+                path: 'src/schemas/x.schema.ts',
+                type: 'schema',
+                action: 'create',
+                description: 'X',
+              },
+            ],
             summary: 'Test',
           },
         }),

--- a/tests/unit/adapters/messaging.adapter.test.ts
+++ b/tests/unit/adapters/messaging.adapter.test.ts
@@ -13,12 +13,8 @@ describe('ConsoleMessagingAdapter', () => {
     });
 
     expect(spy).toHaveBeenCalledTimes(2);
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining('device-token-123')
-    );
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining('Test Notification')
-    );
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('device-token-123'));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('Test Notification'));
     spy.mockRestore();
   });
 
@@ -34,9 +30,7 @@ describe('ConsoleMessagingAdapter', () => {
     });
 
     expect(spy).toHaveBeenCalledTimes(3);
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining('"action":"open_screen"')
-    );
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('"action":"open_screen"'));
     spy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

Bundles three milestones that accumulated under `[Unreleased]` since v0.3.0 into a single release:

- **M4 Atmosphere (3D)** — post-processing pipeline, cosmic skybox, Galaxy Settings panel, cinematic camera presets, ultra quality mode (GLSL shader nebulae, 12k stars, 2.5k dust)
- **M5 Builder v2 (Agent)** — import resolver for dependency-aware context, strategy-based multi-retry recovery (3 attempts), search_files + list_files tools, improved task prompts
- **M6 Cosmos (3D)** — service stars on concentric rings, endpoint planets shaped by HTTP method, curved luminous routes with pulse, wormhole auth gate, orbital navigation, cosmos/tron mode switch, dark/light themes

## Changes

- `package.json`: 0.3.0 → 0.4.0
- `src/index.ts`, `src/routes/mcp.routes.ts`: OpenAPI/MCP version strings bumped
- `CHANGELOG.md`: restructured into per-milestone sections under `[0.4.0]`, removed orphan `---` separator
- `CLAUDE.md`: aligned to current state — version, architecture (added M5 tools, 3D world section with M4/M6 components), test counts (748 server + 244 client), Co-Author line updated
- Prettier reformat applied tree-wide as part of release hygiene

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 748/748 server passing
- [x] `cd client && npm run test` — 244/244 client passing

## Next

Sets the foundation for **M7 MCP Live** — operational MCP server (JSON-RPC 2.0 over HTTP/SSE), agent session management, agent presence in 3D cosmos with activity trails. First bridge milestone joining 3D and Agent tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)