### PR TITLE
feat(client): in-app login for the cosmos — drop VITE_WS_TOKEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Cosmos client login UI
+
+- New auth Zustand store (`stores/auth.store.ts`) with `localStorage` persistence (key `fenice.auth`), supporting `login`, `signup`, `logout`, token refresh, and a dev `pasteToken` backdoor that verifies the JWT against `/api/v1/users/me` before storing.
+- Thin auth API client (`services/auth-api.ts`) covering `/api/v1/auth/{login,signup,refresh,logout}` plus `/api/v1/users/me` and JWT expiry helpers.
+- New `AuthGate` component wraps the app — until a token is present, the cosmos is hidden behind a cosmic-themed login card with three modes: `Sign in`, `Create account`, `Paste token`.
+- `LoginForm`, `SignupForm`, `TokenPasteForm` with shared inline styling (`auth/styles.ts`).
+- New `UserMenu` HUD overlay (top-left) showing username, role badge with role-color dot, full name + email, and a sign-out button. Roles map to the same color palette as agents.
+- `BuilderPromptBar` and `useWorldSocket` now consume the token from `useAuthStore` instead of `VITE_WS_TOKEN`. The env var is no longer read anywhere.
+- `client/.env.example` blanked out — login is in-app now. `QUICKSTART.md` updated to point at the UI flow.
+
+#### Tests
+
+- 12 new auth-store unit tests (login/signup/pasteToken happy + error paths, logout-on-network-fail tolerance, refresh success/failure/no-token, JWT expiry helpers). Total client tests: 270 / 23 files (was 258 / 22).
+
 ### Added — M7 closing (mutating tools wired to builder, run_tests, ActivityBeam)
 
 #### M7.b — Builder tools wired

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -84,12 +84,15 @@ curl http://localhost:3000/api/v1/users/me \
   -H "Authorization: Bearer <your-access-token>"
 ```
 
-Set the client world token:
-```bash
-echo "VITE_WS_TOKEN=<your-access-token>" > client/.env
-```
+Open `http://localhost:5173` and sign in directly from the cosmos client —
+the login form is the first thing you'll see. You can:
+- **Sign in** with an existing account (email + password), or
+- **Create account** for a new user, or
+- **Paste token** to use a JWT minted via curl (useful for testing).
 
-Then refresh `http://localhost:5173` to connect the 3D world client to `GET /api/v1/world-ws`.
+The client persists your session in `localStorage` (key `fenice.auth`) and
+auto-attaches the token to the world WebSocket and to `/api/v1/builder/*`.
+Sign out from the user menu in the top-left corner of the HUD.
 
 ## Other Commands
 

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,9 @@
-VITE_WS_TOKEN=replace-with-access-token
+# Cosmos client environment.
+#
+# As of M7-final, authentication is handled by the in-app login form
+# (see src/components/auth/AuthGate.tsx). VITE_WS_TOKEN is no longer
+# read — sign in from the UI on first load and the token is persisted
+# to localStorage automatically.
+#
+# This file is intentionally empty for now. Add VITE_* variables here
+# if you need to override Vite defaults.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,21 +4,32 @@ import { SidePanel } from './components/SidePanel';
 import { BuilderPromptBar } from './components/builder/BuilderPromptBar';
 import { CosmosSettings } from './components/CosmosSettings';
 import { AgentPanel } from './components/AgentPanel';
+import { AuthGate } from './components/auth/AuthGate';
+import { UserMenu } from './components/auth/UserMenu';
+import { useAuthStore } from './stores/auth.store';
 import { useWorldSocket } from './hooks/useWorldSocket';
 
-const WS_TOKEN = import.meta.env.VITE_WS_TOKEN as string | undefined;
-
-export function App(): React.JSX.Element {
-  useWorldSocket(WS_TOKEN ?? '');
+function AuthenticatedApp(): React.JSX.Element {
+  const accessToken = useAuthStore((s) => s.accessToken) ?? '';
+  useWorldSocket(accessToken);
 
   return (
     <div style={{ width: '100vw', height: '100vh', position: 'relative' }}>
       <Scene />
       <HUD />
+      <UserMenu />
       <SidePanel />
       <BuilderPromptBar />
       <CosmosSettings />
       <AgentPanel />
     </div>
+  );
+}
+
+export function App(): React.JSX.Element {
+  return (
+    <AuthGate>
+      <AuthenticatedApp />
+    </AuthGate>
   );
 }

--- a/client/src/__tests__/auth-store.test.ts
+++ b/client/src/__tests__/auth-store.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { useAuthStore, resetAuthForTest } from '../stores/auth.store';
+import { tokenExpiry, isExpired } from '../services/auth-api';
+
+const fakeUser = {
+  id: 'u1',
+  email: 'a@b.com',
+  username: 'alice',
+  fullName: 'Alice',
+  role: 'agent',
+  active: true,
+  emailVerified: true,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const futureExp = Math.floor((Date.now() + 60_000) / 1000);
+const pastExp = Math.floor((Date.now() - 60_000) / 1000);
+
+function jwt(exp: number): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify({ exp }));
+  return `${header}.${payload}.fakesig`;
+}
+
+const okResponse = (body: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+  }) as unknown as Response;
+
+const errResponse = (status: number, message = 'bad'): Response =>
+  ({
+    ok: false,
+    status,
+    statusText: 'ERR',
+    json: () => Promise.resolve({ error: { message } }),
+  }) as unknown as Response;
+
+describe('auth.store', () => {
+  beforeEach(() => {
+    resetAuthForTest();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    resetAuthForTest();
+  });
+
+  describe('login', () => {
+    it('stores access/refresh/user on success and persists to localStorage', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+        okResponse({
+          user: fakeUser,
+          tokens: { access: jwt(futureExp), refresh: 'r-1' },
+        })
+      );
+
+      await useAuthStore.getState().login('a@b.com', 'secret123!');
+
+      expect(useAuthStore.getState().accessToken).toBeTruthy();
+      expect(useAuthStore.getState().user?.email).toBe('a@b.com');
+      expect(useAuthStore.getState().error).toBeNull();
+      const persisted = JSON.parse(localStorage.getItem('fenice.auth') ?? 'null');
+      expect(persisted?.user?.email).toBe('a@b.com');
+    });
+
+    it('surfaces server error in store and re-throws', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce(errResponse(401, 'Bad credentials'));
+
+      await expect(useAuthStore.getState().login('a@b.com', 'wrong')).rejects.toThrow();
+      expect(useAuthStore.getState().error).toBe('Bad credentials');
+      expect(useAuthStore.getState().accessToken).toBeNull();
+    });
+  });
+
+  describe('signup', () => {
+    it('stores tokens + user on success', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+        okResponse({
+          user: fakeUser,
+          tokens: { access: jwt(futureExp), refresh: 'r-2' },
+        })
+      );
+
+      await useAuthStore.getState().signup({
+        email: 'a@b.com',
+        username: 'alice',
+        fullName: 'Alice',
+        password: 'secret123!',
+      });
+
+      expect(useAuthStore.getState().user?.username).toBe('alice');
+    });
+  });
+
+  describe('pasteToken', () => {
+    it('verifies the token by hitting /users/me before storing', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValueOnce(okResponse(fakeUser));
+
+      await useAuthStore.getState().pasteToken(jwt(futureExp));
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/users/me',
+        expect.objectContaining({
+          headers: { Authorization: expect.stringMatching(/^Bearer /) as string },
+        })
+      );
+      expect(useAuthStore.getState().user).toEqual(fakeUser);
+    });
+
+    it('rejects an invalid token', async () => {
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce(errResponse(401, 'Invalid token'));
+
+      await expect(useAuthStore.getState().pasteToken('not-a-real-token')).rejects.toThrow();
+      expect(useAuthStore.getState().accessToken).toBeNull();
+      expect(useAuthStore.getState().error).toBe('Invalid token');
+    });
+  });
+
+  describe('logout', () => {
+    it('clears state and localStorage even if the network call fails', async () => {
+      vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('network'));
+      useAuthStore.setState({
+        accessToken: jwt(futureExp),
+        refreshToken: 'r-x',
+        user: fakeUser,
+      });
+      localStorage.setItem(
+        'fenice.auth',
+        JSON.stringify({ accessToken: 'x', refreshToken: 'r-x', user: fakeUser })
+      );
+
+      await useAuthStore.getState().logout();
+
+      expect(useAuthStore.getState().accessToken).toBeNull();
+      expect(useAuthStore.getState().user).toBeNull();
+      expect(localStorage.getItem('fenice.auth')).toBeNull();
+    });
+  });
+
+  describe('tryRefresh', () => {
+    it('updates tokens and returns true on success', async () => {
+      useAuthStore.setState({
+        accessToken: jwt(pastExp),
+        refreshToken: 'r-old',
+        user: fakeUser,
+      });
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+        okResponse({ access: jwt(futureExp), refresh: 'r-new' })
+      );
+
+      const ok = await useAuthStore.getState().tryRefresh();
+      expect(ok).toBe(true);
+      expect(useAuthStore.getState().refreshToken).toBe('r-new');
+    });
+
+    it('clears state and returns false on failure', async () => {
+      useAuthStore.setState({
+        accessToken: jwt(pastExp),
+        refreshToken: 'r-bad',
+        user: fakeUser,
+      });
+      vi.spyOn(global, 'fetch').mockResolvedValueOnce(errResponse(401, 'Invalid refresh token'));
+
+      const ok = await useAuthStore.getState().tryRefresh();
+      expect(ok).toBe(false);
+      expect(useAuthStore.getState().accessToken).toBeNull();
+      expect(useAuthStore.getState().user).toBeNull();
+    });
+
+    it('returns false without a refresh token', async () => {
+      const ok = await useAuthStore.getState().tryRefresh();
+      expect(ok).toBe(false);
+    });
+  });
+});
+
+describe('auth-api token helpers', () => {
+  it('tokenExpiry returns ms epoch for valid JWT', () => {
+    const t = jwt(futureExp);
+    expect(tokenExpiry(t)).toBe(futureExp * 1000);
+  });
+
+  it('tokenExpiry returns null for malformed token', () => {
+    expect(tokenExpiry('not-a-jwt')).toBeNull();
+  });
+
+  it('isExpired is true for past exp, false for future exp', () => {
+    expect(isExpired(jwt(pastExp))).toBe(true);
+    expect(isExpired(jwt(futureExp))).toBe(false);
+  });
+});

--- a/client/src/__tests__/auth-store.test.ts
+++ b/client/src/__tests__/auth-store.test.ts
@@ -51,7 +51,7 @@ describe('auth.store', () => {
 
   describe('login', () => {
     it('stores access/refresh/user on success and persists to localStorage', async () => {
-      vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         okResponse({
           user: fakeUser,
           tokens: { access: jwt(futureExp), refresh: 'r-1' },
@@ -68,7 +68,7 @@ describe('auth.store', () => {
     });
 
     it('surfaces server error in store and re-throws', async () => {
-      vi.spyOn(global, 'fetch').mockResolvedValueOnce(errResponse(401, 'Bad credentials'));
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(errResponse(401, 'Bad credentials'));
 
       await expect(useAuthStore.getState().login('a@b.com', 'wrong')).rejects.toThrow();
       expect(useAuthStore.getState().error).toBe('Bad credentials');
@@ -78,7 +78,7 @@ describe('auth.store', () => {
 
   describe('signup', () => {
     it('stores tokens + user on success', async () => {
-      vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         okResponse({
           user: fakeUser,
           tokens: { access: jwt(futureExp), refresh: 'r-2' },
@@ -98,7 +98,7 @@ describe('auth.store', () => {
 
   describe('pasteToken', () => {
     it('verifies the token by hitting /users/me before storing', async () => {
-      const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValueOnce(okResponse(fakeUser));
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(okResponse(fakeUser));
 
       await useAuthStore.getState().pasteToken(jwt(futureExp));
 
@@ -112,7 +112,7 @@ describe('auth.store', () => {
     });
 
     it('rejects an invalid token', async () => {
-      vi.spyOn(global, 'fetch').mockResolvedValueOnce(errResponse(401, 'Invalid token'));
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(errResponse(401, 'Invalid token'));
 
       await expect(useAuthStore.getState().pasteToken('not-a-real-token')).rejects.toThrow();
       expect(useAuthStore.getState().accessToken).toBeNull();
@@ -122,7 +122,7 @@ describe('auth.store', () => {
 
   describe('logout', () => {
     it('clears state and localStorage even if the network call fails', async () => {
-      vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('network'));
+      vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('network'));
       useAuthStore.setState({
         accessToken: jwt(futureExp),
         refreshToken: 'r-x',
@@ -148,7 +148,7 @@ describe('auth.store', () => {
         refreshToken: 'r-old',
         user: fakeUser,
       });
-      vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
         okResponse({ access: jwt(futureExp), refresh: 'r-new' })
       );
 
@@ -163,7 +163,9 @@ describe('auth.store', () => {
         refreshToken: 'r-bad',
         user: fakeUser,
       });
-      vi.spyOn(global, 'fetch').mockResolvedValueOnce(errResponse(401, 'Invalid refresh token'));
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        errResponse(401, 'Invalid refresh token')
+      );
 
       const ok = await useAuthStore.getState().tryRefresh();
       expect(ok).toBe(false);

--- a/client/src/components/auth/AuthGate.tsx
+++ b/client/src/components/auth/AuthGate.tsx
@@ -1,0 +1,111 @@
+import { useState, type ReactNode } from 'react';
+import { useAuthStore } from '../../stores/auth.store';
+import { LoginForm } from './LoginForm';
+import { SignupForm } from './SignupForm';
+import { TokenPasteForm } from './TokenPasteForm';
+
+type Mode = 'login' | 'signup' | 'paste';
+
+interface AuthGateProps {
+  children: ReactNode;
+}
+
+/**
+ * Renders children when authenticated, otherwise shows the login/signup
+ * UI gated on top of a dark cosmic background.
+ */
+export function AuthGate({ children }: AuthGateProps): React.JSX.Element {
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const [mode, setMode] = useState<Mode>('login');
+
+  if (accessToken) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'radial-gradient(circle at 50% 30%, #1a2240 0%, #050714 50%, #000004 100%)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+        fontFamily: 'ui-monospace, monospace',
+      }}
+    >
+      <div
+        style={{
+          width: 380,
+          padding: 28,
+          background: 'rgba(8, 14, 28, 0.92)',
+          border: '1px solid rgba(0, 245, 255, 0.25)',
+          borderRadius: 8,
+          boxShadow: '0 0 60px rgba(0, 245, 255, 0.08), 0 24px 60px rgba(0, 0, 0, 0.6)',
+          color: '#cbe6ff',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 11,
+            letterSpacing: 2,
+            textTransform: 'uppercase',
+            color: '#5eaadd',
+            marginBottom: 4,
+          }}
+        >
+          FENICE
+        </div>
+        <div style={{ fontSize: 18, color: '#fff', marginBottom: 22 }}>
+          {mode === 'login' && 'Sign in to the cosmos'}
+          {mode === 'signup' && 'Create your account'}
+          {mode === 'paste' && 'Paste an access token'}
+        </div>
+
+        {mode === 'login' && <LoginForm />}
+        {mode === 'signup' && <SignupForm />}
+        {mode === 'paste' && <TokenPasteForm />}
+
+        <div
+          style={{
+            marginTop: 20,
+            paddingTop: 16,
+            borderTop: '1px solid rgba(94, 170, 221, 0.18)',
+            display: 'flex',
+            gap: 14,
+            fontSize: 11,
+            color: '#7895b8',
+          }}
+        >
+          {mode !== 'login' && (
+            <button type="button" onClick={() => setMode('login')} style={modeButtonStyle}>
+              Sign in
+            </button>
+          )}
+          {mode !== 'signup' && (
+            <button type="button" onClick={() => setMode('signup')} style={modeButtonStyle}>
+              Create account
+            </button>
+          )}
+          {mode !== 'paste' && (
+            <button type="button" onClick={() => setMode('paste')} style={modeButtonStyle}>
+              Paste token
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const modeButtonStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  color: '#5eaadd',
+  cursor: 'pointer',
+  padding: 0,
+  font: 'inherit',
+  textDecoration: 'underline',
+  textUnderlineOffset: 3,
+};

--- a/client/src/components/auth/LoginForm.tsx
+++ b/client/src/components/auth/LoginForm.tsx
@@ -1,0 +1,53 @@
+import { useState, type FormEvent } from 'react';
+import { useAuthStore } from '../../stores/auth.store';
+import { fieldStyle, labelStyle, primaryButtonStyle, errorStyle } from './styles';
+
+export function LoginForm(): React.JSX.Element {
+  const login = useAuthStore((s) => s.login);
+  const busy = useAuthStore((s) => s.busy);
+  const error = useAuthStore((s) => s.error);
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e: FormEvent): Promise<void> => {
+    e.preventDefault();
+    try {
+      await login(email, password);
+    } catch {
+      // Error is already in the store
+    }
+  };
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} noValidate>
+      <label style={labelStyle}>Email</label>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        autoComplete="email"
+        required
+        style={fieldStyle}
+        disabled={busy}
+      />
+
+      <label style={labelStyle}>Password</label>
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        autoComplete="current-password"
+        required
+        style={fieldStyle}
+        disabled={busy}
+      />
+
+      {error && <div style={errorStyle}>{error}</div>}
+
+      <button type="submit" disabled={busy || !email || !password} style={primaryButtonStyle}>
+        {busy ? 'Connecting…' : 'Sign in'}
+      </button>
+    </form>
+  );
+}

--- a/client/src/components/auth/SignupForm.tsx
+++ b/client/src/components/auth/SignupForm.tsx
@@ -1,0 +1,85 @@
+import { useState, type FormEvent } from 'react';
+import { useAuthStore } from '../../stores/auth.store';
+import { fieldStyle, labelStyle, primaryButtonStyle, errorStyle, hintStyle } from './styles';
+
+export function SignupForm(): React.JSX.Element {
+  const signup = useAuthStore((s) => s.signup);
+  const busy = useAuthStore((s) => s.busy);
+  const error = useAuthStore((s) => s.error);
+
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [fullName, setFullName] = useState('');
+  const [password, setPassword] = useState('');
+
+  const passwordOk = password.length >= 8;
+  const formValid = email && username.length >= 2 && fullName && passwordOk;
+
+  const handleSubmit = async (e: FormEvent): Promise<void> => {
+    e.preventDefault();
+    if (!formValid) return;
+    try {
+      await signup({ email, username, fullName, password });
+    } catch {
+      // Error in store
+    }
+  };
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} noValidate>
+      <label style={labelStyle}>Email</label>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        autoComplete="email"
+        required
+        style={fieldStyle}
+        disabled={busy}
+      />
+
+      <label style={labelStyle}>Username</label>
+      <input
+        type="text"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        autoComplete="username"
+        minLength={2}
+        maxLength={50}
+        required
+        style={fieldStyle}
+        disabled={busy}
+      />
+
+      <label style={labelStyle}>Full name</label>
+      <input
+        type="text"
+        value={fullName}
+        onChange={(e) => setFullName(e.target.value)}
+        autoComplete="name"
+        maxLength={100}
+        required
+        style={fieldStyle}
+        disabled={busy}
+      />
+
+      <label style={labelStyle}>Password</label>
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        autoComplete="new-password"
+        required
+        style={fieldStyle}
+        disabled={busy}
+      />
+      <div style={hintStyle}>Min 8 characters.</div>
+
+      {error && <div style={errorStyle}>{error}</div>}
+
+      <button type="submit" disabled={busy || !formValid} style={primaryButtonStyle}>
+        {busy ? 'Creating…' : 'Create account'}
+      </button>
+    </form>
+  );
+}

--- a/client/src/components/auth/TokenPasteForm.tsx
+++ b/client/src/components/auth/TokenPasteForm.tsx
@@ -1,0 +1,46 @@
+import { useState, type FormEvent } from 'react';
+import { useAuthStore } from '../../stores/auth.store';
+import { fieldStyle, labelStyle, primaryButtonStyle, errorStyle, hintStyle } from './styles';
+
+/**
+ * Dev backdoor — paste a raw access token (e.g. from curl). The token is
+ * verified by calling /api/v1/users/me before being persisted.
+ */
+export function TokenPasteForm(): React.JSX.Element {
+  const pasteToken = useAuthStore((s) => s.pasteToken);
+  const busy = useAuthStore((s) => s.busy);
+  const error = useAuthStore((s) => s.error);
+
+  const [token, setToken] = useState('');
+
+  const handleSubmit = async (e: FormEvent): Promise<void> => {
+    e.preventDefault();
+    if (!token) return;
+    try {
+      await pasteToken(token.trim());
+    } catch {
+      // Error in store
+    }
+  };
+
+  return (
+    <form onSubmit={(e) => void handleSubmit(e)} noValidate>
+      <label style={labelStyle}>Access token (JWT)</label>
+      <textarea
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+        rows={5}
+        style={{ ...fieldStyle, fontFamily: 'ui-monospace, monospace', resize: 'vertical' }}
+        disabled={busy}
+        placeholder="eyJhbGciOiJIUzI1NiIs..."
+      />
+      <div style={hintStyle}>Used for testing — get one with curl + /api/v1/auth/login.</div>
+
+      {error && <div style={errorStyle}>{error}</div>}
+
+      <button type="submit" disabled={busy || !token} style={primaryButtonStyle}>
+        {busy ? 'Verifying…' : 'Verify and continue'}
+      </button>
+    </form>
+  );
+}

--- a/client/src/components/auth/UserMenu.tsx
+++ b/client/src/components/auth/UserMenu.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { useAuthStore } from '../../stores/auth.store';
+
+/**
+ * HUD overlay (top-left) showing the current user with role badge and logout.
+ */
+export function UserMenu(): React.JSX.Element | null {
+  const user = useAuthStore((s) => s.user);
+  const logout = useAuthStore((s) => s.logout);
+  const [open, setOpen] = useState(false);
+
+  if (!user) return null;
+
+  const roleColor = roleColors[user.role] ?? '#5eaadd';
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 16,
+        left: 16,
+        zIndex: 10,
+        fontFamily: 'ui-monospace, monospace',
+        fontSize: 11,
+        color: '#cbe6ff',
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '6px 12px',
+          background: 'rgba(8, 14, 28, 0.85)',
+          border: '1px solid rgba(94, 170, 221, 0.25)',
+          borderRadius: 6,
+          backdropFilter: 'blur(6px)',
+          color: '#cbe6ff',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+          fontSize: 11,
+        }}
+      >
+        <span
+          style={{
+            display: 'inline-block',
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: roleColor,
+            boxShadow: `0 0 6px ${roleColor}`,
+          }}
+        />
+        <span>{user.username}</span>
+        <span style={{ opacity: 0.5 }}>·</span>
+        <span style={{ opacity: 0.6 }}>{user.role}</span>
+      </button>
+
+      {open && (
+        <div
+          style={{
+            marginTop: 6,
+            padding: '10px 12px',
+            background: 'rgba(8, 14, 28, 0.92)',
+            border: '1px solid rgba(94, 170, 221, 0.25)',
+            borderRadius: 6,
+            backdropFilter: 'blur(6px)',
+            minWidth: 200,
+          }}
+        >
+          <div style={{ fontSize: 11, color: '#fff', marginBottom: 2 }}>{user.fullName}</div>
+          <div style={{ fontSize: 10, color: '#7895b8', marginBottom: 10 }}>{user.email}</div>
+          <button
+            type="button"
+            onClick={() => void logout()}
+            style={{
+              width: '100%',
+              padding: '6px 10px',
+              background: 'rgba(255, 60, 60, 0.08)',
+              border: '1px solid rgba(255, 100, 100, 0.3)',
+              borderRadius: 4,
+              color: '#ff8888',
+              fontFamily: 'inherit',
+              fontSize: 11,
+              letterSpacing: 1,
+              textTransform: 'uppercase',
+              cursor: 'pointer',
+            }}
+          >
+            Sign out
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const roleColors: Record<string, string> = {
+  superAdmin: '#ff00aa',
+  admin: '#ff8800',
+  employee: '#ffaa00',
+  agent: '#aa55ff',
+  client: '#5eaadd',
+  vendor: '#5eaadd',
+  user: '#cbe6ff',
+};

--- a/client/src/components/auth/styles.ts
+++ b/client/src/components/auth/styles.ts
@@ -1,0 +1,57 @@
+/** Shared inline styles for the auth forms. */
+
+export const fieldStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 10px',
+  marginBottom: 12,
+  background: 'rgba(0, 0, 12, 0.6)',
+  border: '1px solid rgba(94, 170, 221, 0.25)',
+  borderRadius: 4,
+  color: '#fff',
+  fontSize: 13,
+  fontFamily: 'inherit',
+  outline: 'none',
+  boxSizing: 'border-box',
+};
+
+export const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontSize: 10,
+  letterSpacing: 1.2,
+  textTransform: 'uppercase',
+  color: '#5eaadd',
+  marginBottom: 4,
+};
+
+export const primaryButtonStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 14px',
+  marginTop: 6,
+  background: 'linear-gradient(135deg, rgba(0, 245, 255, 0.18) 0%, rgba(0, 245, 255, 0.08) 100%)',
+  border: '1px solid rgba(0, 245, 255, 0.55)',
+  borderRadius: 4,
+  color: '#cbe6ff',
+  fontSize: 12,
+  fontWeight: 600,
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+export const errorStyle: React.CSSProperties = {
+  marginBottom: 10,
+  padding: '8px 10px',
+  background: 'rgba(255, 60, 60, 0.12)',
+  border: '1px solid rgba(255, 100, 100, 0.4)',
+  borderRadius: 4,
+  color: '#ff8888',
+  fontSize: 11,
+};
+
+export const hintStyle: React.CSSProperties = {
+  marginTop: -6,
+  marginBottom: 12,
+  fontSize: 10,
+  color: '#7895b8',
+};

--- a/client/src/components/builder/BuilderPromptBar.tsx
+++ b/client/src/components/builder/BuilderPromptBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useRef } from 'react';
 import { useBuilderStore } from '../../stores/builder.store';
 import { useViewStore } from '../../stores/view.store';
+import { useAuthStore } from '../../stores/auth.store';
 import {
   submitBuilderPrompt,
   fetchBuilderJob,
@@ -20,9 +21,8 @@ import { BuilderTaskSelector } from './BuilderTaskSelector';
 import { BuilderDraftResult } from './BuilderDraftResult';
 import { BuilderResultPanel } from './BuilderResultPanel';
 
-const WS_TOKEN = import.meta.env.VITE_WS_TOKEN as string | undefined;
-
 export function BuilderPromptBar(): React.JSX.Element {
+  const authToken = useAuthStore((s) => s.accessToken);
   const expanded = useBuilderStore((s) => s.expanded);
   const toggleExpanded = useBuilderStore((s) => s.toggleExpanded);
   const prompt = useBuilderStore((s) => s.prompt);
@@ -74,11 +74,11 @@ export function BuilderPromptBar(): React.JSX.Element {
   const canSubmit = prompt.length >= 10 && prompt.length <= 2000 && !submitting && !isRunning;
 
   const handleSubmit = useCallback(async () => {
-    if (!canSubmit || !WS_TOKEN) return;
+    if (!canSubmit || !authToken) return;
     setSubmitting(true);
     try {
       const { jobId: newJobId } = await submitBuilderPrompt(
-        WS_TOKEN,
+        authToken,
         prompt,
         dryRun,
         taskType,
@@ -100,18 +100,18 @@ export function BuilderPromptBar(): React.JSX.Element {
   );
 
   const handleApprove = useCallback(async () => {
-    if (!jobId || !WS_TOKEN || !plan || !summary) return;
+    if (!jobId || !authToken || !plan || !summary) return;
     try {
-      await approveBuilderJob(WS_TOKEN, jobId, { files: plan, summary });
+      await approveBuilderJob(authToken, jobId, { files: plan, summary });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Approve failed');
     }
   }, [jobId, plan, summary, setError]);
 
   const handleReject = useCallback(async () => {
-    if (!jobId || !WS_TOKEN) return;
+    if (!jobId || !authToken) return;
     try {
-      await rejectBuilderJob(WS_TOKEN, jobId);
+      await rejectBuilderJob(authToken, jobId);
       dismiss();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Reject failed');
@@ -119,9 +119,9 @@ export function BuilderPromptBar(): React.JSX.Element {
   }, [jobId, dismiss, setError]);
 
   const handleRollback = useCallback(async () => {
-    if (!jobId || !WS_TOKEN || !commitHash) return;
+    if (!jobId || !authToken || !commitHash) return;
     try {
-      await rollbackBuilderJob(WS_TOKEN, jobId);
+      await rollbackBuilderJob(authToken, jobId);
       dismiss();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Rollback failed');
@@ -130,11 +130,11 @@ export function BuilderPromptBar(): React.JSX.Element {
 
   // Fetch full job details when status reaches completed or failed
   useEffect(() => {
-    if (!jobId || !WS_TOKEN) return;
+    if (!jobId || !authToken) return;
     if (status !== 'completed' && status !== 'completed_draft' && status !== 'failed') return;
 
     let cancelled = false;
-    void fetchBuilderJob(WS_TOKEN, jobId)
+    void fetchBuilderJob(authToken, jobId)
       .then((job) => {
         if (cancelled) return;
         if ((job.status === 'completed' || job.status === 'completed_draft') && job.result) {
@@ -155,10 +155,10 @@ export function BuilderPromptBar(): React.JSX.Element {
 
   // Fetch plan details when status reaches plan_ready
   useEffect(() => {
-    if (!jobId || !WS_TOKEN || status !== 'plan_ready') return;
+    if (!jobId || !authToken || status !== 'plan_ready') return;
 
     let cancelled = false;
-    void fetchBuilderJob(WS_TOKEN, jobId)
+    void fetchBuilderJob(authToken, jobId)
       .then((job) => {
         if (cancelled || !job.plan) return;
         setPlan(job.plan.files, job.plan.summary);

--- a/client/src/services/auth-api.ts
+++ b/client/src/services/auth-api.ts
@@ -1,0 +1,112 @@
+/**
+ * Thin client for FENICE's /api/v1/auth/* endpoints.
+ * Returns raw responses; the auth store handles state and persistence.
+ */
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  username: string;
+  fullName: string;
+  role: string;
+  active: boolean;
+  emailVerified: boolean;
+  pictureUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AuthTokens {
+  access: string;
+  refresh: string;
+}
+
+export interface AuthResponse {
+  user: AuthUser;
+  tokens: AuthTokens;
+}
+
+interface ApiError {
+  error?: { code?: string; message?: string };
+  message?: string;
+}
+
+async function parseErrorMessage(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as ApiError;
+    return body.error?.message ?? body.message ?? `${res.status} ${res.statusText}`;
+  } catch {
+    return `${res.status} ${res.statusText}`;
+  }
+}
+
+export async function login(email: string, password: string): Promise<AuthResponse> {
+  const res = await fetch('/api/v1/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) throw new Error(await parseErrorMessage(res));
+  return (await res.json()) as AuthResponse;
+}
+
+export async function signup(input: {
+  email: string;
+  username: string;
+  fullName: string;
+  password: string;
+}): Promise<AuthResponse> {
+  const res = await fetch('/api/v1/auth/signup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) throw new Error(await parseErrorMessage(res));
+  return (await res.json()) as AuthResponse;
+}
+
+export async function refresh(refreshToken: string): Promise<AuthTokens> {
+  const res = await fetch('/api/v1/auth/refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken }),
+  });
+  if (!res.ok) throw new Error(await parseErrorMessage(res));
+  return (await res.json()) as AuthTokens;
+}
+
+export async function logout(accessToken: string): Promise<void> {
+  await fetch('/api/v1/auth/logout', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  // Best-effort — even if it fails (network, expired), the local state is cleared
+}
+
+export async function fetchMe(accessToken: string): Promise<AuthUser> {
+  const res = await fetch('/api/v1/users/me', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) throw new Error(await parseErrorMessage(res));
+  return (await res.json()) as AuthUser;
+}
+
+/** Decodes a JWT exp claim. Returns null on malformed tokens. */
+export function tokenExpiry(token: string): number | null {
+  const parts = token.split('.');
+  if (parts.length < 2) return null;
+  try {
+    const base64url = parts[1] ?? '';
+    const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+    const payload = JSON.parse(atob(padded)) as { exp?: unknown };
+    return typeof payload.exp === 'number' ? payload.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isExpired(token: string): boolean {
+  const exp = tokenExpiry(token);
+  return exp === null || Date.now() >= exp;
+}

--- a/client/src/stores/auth.store.ts
+++ b/client/src/stores/auth.store.ts
@@ -1,0 +1,182 @@
+import { create } from 'zustand';
+import * as authApi from '../services/auth-api';
+import type { AuthUser } from '../services/auth-api';
+
+const STORAGE_KEY = 'fenice.auth';
+
+interface PersistedAuth {
+  accessToken: string;
+  refreshToken: string;
+  user: AuthUser;
+}
+
+function readPersisted(): PersistedAuth | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedAuth;
+    if (!parsed.accessToken || !parsed.user) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writePersisted(value: PersistedAuth | null): void {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  if (value === null) {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+}
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  user: AuthUser | null;
+  busy: boolean;
+  error: string | null;
+
+  login: (email: string, password: string) => Promise<void>;
+  signup: (input: {
+    email: string;
+    username: string;
+    fullName: string;
+    password: string;
+  }) => Promise<void>;
+  /** Pastes a raw token (dev backdoor for testing without form). */
+  pasteToken: (accessToken: string, refreshToken?: string) => Promise<void>;
+  logout: () => Promise<void>;
+  /** Try to refresh the access token. Logs out on failure. */
+  tryRefresh: () => Promise<boolean>;
+  clearError: () => void;
+}
+
+const persisted = readPersisted();
+
+export const useAuthStore = create<AuthState>((set, get) => ({
+  accessToken: persisted?.accessToken ?? null,
+  refreshToken: persisted?.refreshToken ?? null,
+  user: persisted?.user ?? null,
+  busy: false,
+  error: null,
+
+  login: async (email, password) => {
+    set({ busy: true, error: null });
+    try {
+      const res = await authApi.login(email, password);
+      writePersisted({
+        accessToken: res.tokens.access,
+        refreshToken: res.tokens.refresh,
+        user: res.user,
+      });
+      set({
+        accessToken: res.tokens.access,
+        refreshToken: res.tokens.refresh,
+        user: res.user,
+        busy: false,
+        error: null,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Login failed';
+      set({ busy: false, error: message });
+      throw err;
+    }
+  },
+
+  signup: async (input) => {
+    set({ busy: true, error: null });
+    try {
+      const res = await authApi.signup(input);
+      writePersisted({
+        accessToken: res.tokens.access,
+        refreshToken: res.tokens.refresh,
+        user: res.user,
+      });
+      set({
+        accessToken: res.tokens.access,
+        refreshToken: res.tokens.refresh,
+        user: res.user,
+        busy: false,
+        error: null,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Signup failed';
+      set({ busy: false, error: message });
+      throw err;
+    }
+  },
+
+  pasteToken: async (accessToken, refreshToken) => {
+    set({ busy: true, error: null });
+    try {
+      const user = await authApi.fetchMe(accessToken);
+      const persistedValue: PersistedAuth = {
+        accessToken,
+        refreshToken: refreshToken ?? '',
+        user,
+      };
+      writePersisted(persistedValue);
+      set({
+        accessToken,
+        refreshToken: refreshToken ?? null,
+        user,
+        busy: false,
+        error: null,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Token rejected';
+      set({ busy: false, error: message });
+      throw err;
+    }
+  },
+
+  logout: async () => {
+    const token = get().accessToken;
+    if (token) {
+      // Fire-and-forget — local state is cleared regardless
+      try {
+        await authApi.logout(token);
+      } catch {
+        // Ignore network errors
+      }
+    }
+    writePersisted(null);
+    set({ accessToken: null, refreshToken: null, user: null, error: null });
+  },
+
+  tryRefresh: async () => {
+    const { refreshToken, user } = get();
+    if (!refreshToken || !user) return false;
+    try {
+      const tokens = await authApi.refresh(refreshToken);
+      writePersisted({
+        accessToken: tokens.access,
+        refreshToken: tokens.refresh,
+        user,
+      });
+      set({ accessToken: tokens.access, refreshToken: tokens.refresh });
+      return true;
+    } catch {
+      writePersisted(null);
+      set({ accessToken: null, refreshToken: null, user: null });
+      return false;
+    }
+  },
+
+  clearError: () => set({ error: null }),
+}));
+
+/** Test-only: reset the store and storage. */
+export function resetAuthForTest(): void {
+  writePersisted(null);
+  useAuthStore.setState({
+    accessToken: null,
+    refreshToken: null,
+    user: null,
+    busy: false,
+    error: null,
+  });
+}


### PR DESCRIPTION
## Why

> *"Senti una domanda lecita ma perché non ho un login nel cosmo perché devo essere costretto a fare il login sulla porta 3000 o quella che sia e a passare il token non so dove nella porta 5173?"*

Fair point. The cosmos client read `VITE_WS_TOKEN` at boot and bailed with "Missing VITE_WS_TOKEN" otherwise. So the testing flow was:

1. `curl /api/v1/auth/login` to get a JWT
2. paste it into `client/.env` as `VITE_WS_TOKEN=...`
3. restart Vite

Painful. Especially as the first thing anyone hits when trying M7.

## What lands

A login card that's the first thing you see in the cosmos. Three modes:

- **Sign in** (email + password)
- **Create account** (email + username + fullName + password)
- **Paste token** (dev backdoor — verifies the JWT against `/users/me` before storing)

After auth, the cosmos appears with a `UserMenu` in the top-left showing username, role-color dot, and sign-out button. Token is persisted to `localStorage` (key `fenice.auth`) and auto-attached to:
- the world WebSocket (`useWorldSocket` reads from `useAuthStore`)
- `/api/v1/builder/*` calls in `BuilderPromptBar` (13 callsites updated)

## Architecture

```
new files:
  services/auth-api.ts            — /api/v1/auth/* + /users/me + JWT helpers
  stores/auth.store.ts            — Zustand + localStorage persistence
  components/auth/AuthGate.tsx    — gate component
  components/auth/LoginForm.tsx
  components/auth/SignupForm.tsx
  components/auth/TokenPasteForm.tsx
  components/auth/UserMenu.tsx
  components/auth/styles.ts       — shared inline styles

modified:
  App.tsx                         — wraps in <AuthGate>, adds <UserMenu>
  hooks/useWorldSocket.ts         — token comes from store now
  components/builder/BuilderPromptBar.tsx — same
  client/.env.example             — blanked, points at the UI
  QUICKSTART.md                   — login section rewritten
```

## Role colors in UserMenu

Reuses the same palette as agent entities for cognitive consistency:
- `superAdmin` magenta · `admin` amber · `employee` warm
- `agent` violet · `client/vendor` cyan · `user` neutral

## Tests

12 new auth-store unit tests covering:
- login / signup / pasteToken happy + error paths
- pasteToken hits `/users/me` before storing
- logout clears state and localStorage even if the network call fails
- tryRefresh success / failure / missing-refresh-token
- JWT expiry helpers (`tokenExpiry`, `isExpired`)

Total client tests: **270 / 23 files** (was 258 / 22). Server tests unchanged.

## Test plan

- [x] `cd client && npm run typecheck` — clean
- [x] `cd client && npm run lint` — clean
- [x] `cd client && npm run test` — 270/270 passing
- [x] Verified `App.tsx` still works without `VITE_WS_TOKEN` set
- [ ] Manual: open `http://localhost:5173`, sign in with seed admin (`admin@formray.io` / `change-me-in-production`), see the cosmos appear and the UserMenu in the top-left

🤖 Generated with [Claude Code](https://claude.com/claude-code)